### PR TITLE
Fix execution-timeout input name in action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -40,7 +40,7 @@ inputs:
     description: 'Env variables for function. Multiline'
     default: ''
     required: false
-  execution_timeout:
+  execution-timeout:
     description: 'Execution timeout in seconds'
     default: '5'
     required: false


### PR DESCRIPTION
Execution timeout input is [written in snake_case in action.yml](https://github.com/yc-actions/yc-sls-function/blob/main/action.yml#L43), however it's [expected to be written in kebab-case in src/main.ts](https://github.com/yc-actions/yc-sls-function/blob/main/src/main.ts#L125).

Because of that input value `execution_timeout` is ignored during deploy to Yandex Cloud.